### PR TITLE
Update StlRenderer.php to support multiple formats

### DIFF
--- a/src/Renderer/StlRenderer.php
+++ b/src/Renderer/StlRenderer.php
@@ -6,14 +6,16 @@ final class StlRenderer extends AbstractOpenScadBinaryRenderer
 {
     public function __construct(
         ?string $openScadPath = null,
+        ?string $exportFormat = 'stl',
     ) {
         $this->setBinary($openScadPath ?? $this->findBinary());
+        $this->exportFormat = $exportFormat;
     }
 
     protected function getArguments(): array
     {
         return [
-            '--export-format', 'stl',
+            '--export-format', $this->exportFormat,
             '-o', self::TARGET_FILE_PLACEHOLDER,
             self::SCAD_FILE_PLACEHOLDER,
         ];


### PR DESCRIPTION
Add a variable exportFormat, defaulting to 'stl', which can be overridden easily to values such as 'binstl' and 'asciistl' (which might be a more sensible default)

For example

$model->withRenderer(new StlRenderer(exportFormat: 'binstl'))->render('generated/output.stl');